### PR TITLE
상품 엔티티의 생성일, 수정일 자동으로 관리하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/hello/until/UntilApplication.java
+++ b/src/main/java/hello/until/UntilApplication.java
@@ -2,8 +2,10 @@ package hello.until;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class UntilApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/hello/until/item/entity/Item.java
+++ b/src/main/java/hello/until/item/entity/Item.java
@@ -1,23 +1,27 @@
 package hello.until.item.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Setter
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 public class Item {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     private Integer price;
+    @Column(updatable = false)
+    @CreatedDate
     private LocalDateTime createdAt;
+    @LastModifiedDate
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/hello/until/item/entity/Item.java
+++ b/src/main/java/hello/until/item/entity/Item.java
@@ -21,9 +21,10 @@ public class Item {
     private Long id;
     private String name;
     private Integer price;
-    @Column(updatable = false)
+    @Column(updatable = false, nullable = false)
     @CreatedDate
     private LocalDateTime createdAt;
+    @Column(nullable = false)
     @LastModifiedDate
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/hello/until/item/entity/Item.java
+++ b/src/main/java/hello/until/item/entity/Item.java
@@ -1,8 +1,7 @@
 package hello.until.item.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -11,6 +10,9 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 public class Item {

--- a/src/test/java/hello/until/item/repository/ItemRepositoryTest.java
+++ b/src/test/java/hello/until/item/repository/ItemRepositoryTest.java
@@ -1,0 +1,69 @@
+package hello.until.item.repository;
+
+import hello.until.item.entity.Item;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class ItemRepositoryTest {
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @Test
+    @DisplayName("상품 생성일을 지정하지 않아도 생성일이 등록된다. (테스트에서는 +1초 오차까지 허용)")
+    void autoCreatedAt() {
+        // given
+        var item = Item.builder()
+                .id(1L)
+                .name("테스트 상품")
+                .price(10_000)
+                .build();
+        var expected = LocalDateTime.now().plusSeconds(1);
+
+        // when
+        var savedItem = this.itemRepository.save(item);
+
+        // then
+        var createdAt = savedItem.getCreatedAt();
+        assertThat(createdAt).isNotNull();
+        assertThat(createdAt).isBeforeOrEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("상품 수정일을 지정하지 않아도 수정일이 업데이트된다. (테스트에서는 +1초 오차까지 허용)")
+    void autoUpdatedAt() {
+        // given
+        var item = Item.builder()
+                .id(1L)
+                .name("테스트 상품")
+                .price(10_000)
+                .build();
+        item = this.itemRepository.save(item);
+        var createdAt = item.getCreatedAt();
+
+        var delaySeconds = 5;
+        Awaitility.await()
+                .pollDelay(Duration.ofSeconds(delaySeconds))
+                .until(() -> true);
+        var expected1 = createdAt.plusSeconds(delaySeconds);
+        var expected2 = LocalDateTime.now().plusSeconds(1);
+
+        // when
+        item.setName("수정한 테스트 상품");
+        var updatedItem = this.itemRepository.saveAndFlush(item);
+
+        // then
+        var updatedAt = updatedItem.getUpdatedAt();
+        assertThat(updatedAt).isNotNull();
+        assertThat(updatedAt).isAfterOrEqualTo(expected1);
+        assertThat(updatedAt).isBeforeOrEqualTo(expected2);
+    }
+}

--- a/src/test/java/hello/until/item/repository/ItemRepositoryTest.java
+++ b/src/test/java/hello/until/item/repository/ItemRepositoryTest.java
@@ -5,6 +5,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.time.Duration;
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class ItemRepositoryTest {
     @Autowired
     private ItemRepository itemRepository;

--- a/src/test/java/hello/until/item/service/ItemServiceTest.java
+++ b/src/test/java/hello/until/item/service/ItemServiceTest.java
@@ -27,12 +27,13 @@ class ItemServiceTest {
     void beforeEach() {
         this.itemService = new ItemService(this.itemRepository);
 
-        this.testItem = new Item();
-        this.testItem.setId(1L);
-        this.testItem.setName("테스트 상품");
-        this.testItem.setPrice(10_000);
-        this.testItem.setCreatedAt(LocalDateTime.now());
-        this.testItem.setUpdatedAt(LocalDateTime.now());
+        this.testItem = Item.builder()
+                .id(1L)
+                .name("테스트 상품")
+                .price(10_000)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
     }
 
     @Test


### PR DESCRIPTION
## 개요

- related issue : #15 
- 상품 생성일, 수정일을 JPA 에서 자동으로 관리해주는 기능 추가
- 비동기 테스트를 위한 Awaitility 라이브러리 추가 

## 노트

- DataJpaTest 환경에서 테스트 진행
- 위 환경은 기본적으로 application.yml 의 DB URL 설정을 무시하고 H2 DB 를 무조건 씀 (실제 DB 와 상관 없이 가볍게 테스트하기 위해)
- 현재 USER 예약어 문제를 DB URL 에 키워드 제외 옵션으로 풀었기 때문에 그냥 실행하면 에러가 남
- application.yml 에 있는 설정을 그대로 쓰도록 현재는 해결한 상태
- 이후 실제 DB 를 도입하는 시점에서
  - application.yml 의 test profile 에서 현재 H2 DB URL 을 유지하면서 해당 테스트에서 test profile 을 활성화 하거나
  - 예약어 문제를 다른 방향으로 풀고 application.yml 설정 무시하는 기본 동작으로 돌리거나 해야 할 듯