### PR TITLE
CustomException 용 전역 Advice 추가 

### DIFF
--- a/src/main/java/hello/until/exception/CustomExceptionAdvice.java
+++ b/src/main/java/hello/until/exception/CustomExceptionAdvice.java
@@ -1,0 +1,13 @@
+package hello.until.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class CustomExceptionAdvice {
+    @ExceptionHandler
+    public ResponseEntity<ExceptionCode> handleCustomException(CustomException e) {
+        return new ResponseEntity<>(e.getCode(), e.getCode().getHttpStatus());
+    }
+}

--- a/src/main/java/hello/until/exception/ExceptionCode.java
+++ b/src/main/java/hello/until/exception/ExceptionCode.java
@@ -1,14 +1,18 @@
 package hello.until.exception;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ExceptionCode {
     NO_ITEM_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 상품이 없습니다.");
 
+    @JsonIgnore
     private final HttpStatus httpStatus;
     private final String message;
 }


### PR DESCRIPTION
## 개요

- related issue : #34
- CustomException 을 잡아서 설정된 ExceptionCode 에 맞춰서 응답 

## 노트

- 컨트롤러에서 에러 응답이 필요한 경우 ExceptionCode 에 해당 케이스를 추가하고
- CustomException 으로 감싸서 던지면 저기서 잡아서 처리합니다. 