### PR TITLE
refactor : User Entity 수정

### DIFF
--- a/src/main/java/hello/until/exception/ExceptionCode.java
+++ b/src/main/java/hello/until/exception/ExceptionCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ExceptionCode {
-    NO_ITEM_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 상품이 없습니다.");
+    NO_ITEM_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 상품이 없습니다.")
+    ,DUPLICATE_EAMIL_USER_TO_CREATE(HttpStatus.CONFLICT, "이미 가입 된 회원 메일입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/hello/until/user/dto/response/UserResponse.java
+++ b/src/main/java/hello/until/user/dto/response/UserResponse.java
@@ -1,9 +1,11 @@
 package hello.until.user.dto.response;
 
-import hello.until.user.entity.User;
-
 import java.time.LocalDateTime;
 
+import hello.until.user.entity.User;
+import lombok.Getter;
+
+@Getter
 public class UserResponse {
     private final Long id;
     private final String email;

--- a/src/main/java/hello/until/user/entity/User.java
+++ b/src/main/java/hello/until/user/entity/User.java
@@ -2,7 +2,13 @@ package hello.until.user.entity;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -12,6 +18,7 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
+@EntityListeners(AuditingEntityListener.class)
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -20,21 +27,22 @@ public class User {
     private String email;
     private String password;
 
+    @Column(updatable = false, nullable = false)
+    @CreatedDate
     private LocalDateTime createdAt;
+    
+    @Column(nullable = false)
+    @LastModifiedDate
     private LocalDateTime updatedAt;
 
     public void updateEmail(String email){
         if(email != null){
-            LocalDateTime currentDateTime = LocalDateTime.now();
             this.email = email;
-            this.updatedAt = currentDateTime;
         }
     }
     public void updatePassword(String password){
         if(password != null){
-            LocalDateTime currentDateTime = LocalDateTime.now();
             this.password = password;
-            this.updatedAt = currentDateTime;
         }
     }
 

--- a/src/main/java/hello/until/user/service/UserService.java
+++ b/src/main/java/hello/until/user/service/UserService.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import hello.until.exception.CustomException;
+import hello.until.exception.ExceptionCode;
 import hello.until.user.entity.User;
 import hello.until.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -20,14 +22,11 @@ public class UserService {
 	@Transactional 
 	public void createUser(String email, String password) {
 		
-		LocalDateTime currentDateTime = LocalDateTime.now();
 		validateUser(email); 
 			
 		User user = new User();
 		user.setEmail(email);
 		user.setPassword(password);
-		user.setCreatedAt(currentDateTime);
-		user.setUpdatedAt(currentDateTime);
 		userRepository.save(user);
 		
 	}
@@ -36,7 +35,7 @@ public class UserService {
 		Optional<User> user = userRepository.findByEmail(email);
 		
 		if(user.isPresent())
-			throw new IllegalStateException("이미 가입 된 회원 메일입니다.");
+			throw new CustomException(ExceptionCode.DUPLICATE_EAMIL_USER_TO_CREATE);
 	}
 
 	public Optional<User> updateUser(long userId, String email, String password){

--- a/src/test/java/hello/until/user/repository/UserRepositoryTest.java
+++ b/src/test/java/hello/until/user/repository/UserRepositoryTest.java
@@ -1,16 +1,20 @@
 package hello.until.user.repository;
 
 
-import hello.until.user.entity.User;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-import java.time.LocalDateTime;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import hello.until.user.entity.User;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -22,21 +26,20 @@ public class UserRepositoryTest {
     @DisplayName("새 User 저장")
     public void saveUser() {
         // given
-        LocalDateTime currentDateTime = LocalDateTime.now();
         User user = new User();
         user.setId(1L);
         user.setEmail("test@test.com");
         user.setPassword("12345678");
-        user.setCreatedAt(currentDateTime);
-        user.setUpdatedAt(currentDateTime);
+        LocalDateTime expected = LocalDateTime.now().plusSeconds(1);
+        
         // when
         User dbUser = userRepository.save(user);
 
         // then
         assertEquals(dbUser.getEmail(), user.getEmail());
         assertEquals(dbUser.getPassword(), user.getPassword());
-        assertEquals(dbUser.getCreatedAt(), currentDateTime);
-        assertEquals(dbUser.getUpdatedAt(), currentDateTime);
+        assertThat(dbUser.getCreatedAt()).isBefore(expected);
+        assertThat(dbUser.getUpdatedAt()).isBefore(expected);
     }
 
     @Test
@@ -48,17 +51,27 @@ public class UserRepositoryTest {
         user.setId(1L);
         user.setEmail("test@test.com");
         user.setPassword("12345678");
-        user.setCreatedAt(currentDateTime);
-        user.setUpdatedAt(currentDateTime);
         User dbUser = userRepository.save(user);
-        dbUser.updateEmail("test2@test.com");
+        
+        LocalDateTime expected = LocalDateTime.now().plusSeconds(1);
+        
+        int delaySeconds = 3;
+        Awaitility.await()
+                .pollDelay(Duration.ofSeconds(delaySeconds))
+                .until(() -> true);
+       
+        LocalDateTime expectedUpdate1 = dbUser.getCreatedAt().plusSeconds(delaySeconds);
+        LocalDateTime expectedUpdate2 = LocalDateTime.now().plusSeconds(1);
+        
         // when
-        User savedUser = userRepository.save(dbUser);
+        dbUser.updateEmail("test2@test.com");
+        User savedUser = userRepository.saveAndFlush(dbUser);
 
         // then
         assertEquals(dbUser.getEmail(), savedUser.getEmail());
         assertEquals(dbUser.getPassword(), savedUser.getPassword());
-        assertEquals(dbUser.getCreatedAt(), savedUser.getCreatedAt());
-        assertEquals(dbUser.getUpdatedAt(), savedUser.getUpdatedAt());
+        
+        assertThat(savedUser.getUpdatedAt()).isAfterOrEqualTo(expectedUpdate1);
+        assertThat(savedUser.getUpdatedAt()).isBeforeOrEqualTo(expectedUpdate2);
     }
 }

--- a/src/test/java/hello/until/user/service/UserServiceTest.java
+++ b/src/test/java/hello/until/user/service/UserServiceTest.java
@@ -35,8 +35,6 @@ public class UserServiceTest {
 	    testUser.setId(1L);
 	    testUser.setEmail("test@test.com");
 	    testUser.setPassword("12341234");
-	    testUser.setCreatedAt(LocalDateTime.now());
-	    testUser.setUpdatedAt(LocalDateTime.now());
 	}
 
 	@Test


### PR DESCRIPTION
js number 범위가 Long의 범위보다 넓기 때문에 해당 내용 추가
@JsonSerialize(using = ToStringSerializer.class)
생성일/수정일 자동 추적
Auditing Listenr 추가 및 @CreatedDate @LastModifiedDate
생성일/수정일 추적에 따른 직접 데이터 입력 부분 제거
user 생성, user 수정 관련 내용에서 수정 예정
이에 따른 testcase 수정 예정
#47 
