### PR TITLE
Feat : 유저 다중조회 기능

### DIFF
--- a/src/main/java/hello/until/user/controller/UserController.java
+++ b/src/main/java/hello/until/user/controller/UserController.java
@@ -7,6 +7,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -56,6 +59,14 @@ public class UserController {
 			return ResponseEntity.ok(new GetUserResponse(user.get()));
 		else
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 유저를 찾을 수 없습니다.");
+	}
+	
+	@GetMapping("/")
+	public  Page<GetUserResponse> getUsers(Optional<Integer> page) {
+		Pageable pageable  = PageRequest.of(page.isPresent() ? page.get() : 0, 5);
+        Page<User> userPage = userService.getUsers(pageable);
+        return userPage.map(user -> new GetUserResponse(user));
+
 	}
 
 }

--- a/src/main/java/hello/until/user/controller/UserController.java
+++ b/src/main/java/hello/until/user/controller/UserController.java
@@ -61,7 +61,7 @@ public class UserController {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 유저를 찾을 수 없습니다.");
 	}
 	
-	@GetMapping("/")
+	@GetMapping("/getUsers")
 	public  Page<GetUserResponse> getUsers(Optional<Integer> page) {
 		Pageable pageable  = PageRequest.of(page.isPresent() ? page.get() : 0, 5);
         Page<User> userPage = userService.getUsers(pageable);

--- a/src/main/java/hello/until/user/repository/UserRepository.java
+++ b/src/main/java/hello/until/user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package hello.until.user.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import hello.until.user.entity.User;
@@ -9,4 +11,6 @@ import hello.until.user.entity.User;
 public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findByEmail(String email);
+	
+	Page<User> findAllByOrderByIdDesc(Pageable pageable);
 }

--- a/src/main/java/hello/until/user/service/UserService.java
+++ b/src/main/java/hello/until/user/service/UserService.java
@@ -3,12 +3,13 @@ package hello.until.user.service;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import hello.until.user.entity.User;
 import hello.until.user.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -56,5 +57,14 @@ public class UserService {
     @Transactional(readOnly = true)
     public Optional<User> getUserById(long id){
         return userRepository.findById(id);
+    }
+    
+    @Transactional(readOnly = true)
+    public Page<User>getUsers(Pageable pageable){
+    	Page<User> users = userRepository.findAllByOrderByIdDesc(pageable);
+		
+    	
+    	return users;
+    	
     }
 }

--- a/src/test/java/hello/until/user/service/UserServiceTest.java
+++ b/src/test/java/hello/until/user/service/UserServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +15,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import hello.until.user.entity.User;
 import hello.until.user.repository.UserRepository;
@@ -26,7 +32,9 @@ public class UserServiceTest {
 	private UserService userService;
 
 	private User testUser;
-
+	
+	private Page<User> testUsers;
+	
 	@BeforeEach
 	void beforeEach() {
 		userService = new UserService(userRepository);
@@ -37,6 +45,8 @@ public class UserServiceTest {
 	    testUser.setPassword("12341234");
 	    testUser.setCreatedAt(LocalDateTime.now());
 	    testUser.setUpdatedAt(LocalDateTime.now());
+	    
+
 	}
 
 	@Test
@@ -93,6 +103,38 @@ public class UserServiceTest {
 
         // then
         assertThat(result.isEmpty()).isTrue();
+	}
+
+	
+	@Test
+	@DisplayName("다중회원조회 테스트")
+	void getUsers() {
+		Pageable pageable  = PageRequest.of(0, 5);
+		
+	    List<User> userList = new ArrayList<>();
+	    for (int i = 1; i <= 5; i++) {
+	        User user = new User();
+	        user.setId((long) i);
+	        user.setEmail("test" + i + "@test.com");
+	        user.setPassword("password" + i);
+	        userList.add(user);
+	    }
+		
+	    
+	    //given
+	    Mockito.when(this.userRepository.findAllByOrderByIdDesc(pageable))
+	           .thenReturn(new PageImpl<>(userList, pageable, userList.size()));
+	    
+	    //when
+	    Page<User> users = userService.getUsers(pageable);
+	    
+	    //then
+	    assertThat(users).isNotNull();
+	    assertThat(users.getContent().size()).isEqualTo(5);
+	    assertThat(users.getContent().get(4).getEmail()).isEqualTo("test5@test.com");
+		
+		
+		
 	}
 
 }

--- a/src/test/java/hello/until/user/service/UserServiceTest.java
+++ b/src/test/java/hello/until/user/service/UserServiceTest.java
@@ -2,6 +2,7 @@ package hello.until.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -129,9 +131,16 @@ public class UserServiceTest {
 	    Page<User> users = userService.getUsers(pageable);
 	    
 	    //then
+	    var userCaptor = ArgumentCaptor.forClass(Pageable.class);
+	    Mockito.verify(this.userRepository, times(1)).findAllByOrderByIdDesc(userCaptor.capture());
+	    var passedItem = userCaptor.getValue();
+	    
+	    assertThat(passedItem.getPageNumber()).isEqualTo(0);
+	    assertThat(passedItem.getPageSize()).isEqualTo(5);
+	    
+	    
 	    assertThat(users).isNotNull();
 	    assertThat(users.getContent().size()).isEqualTo(5);
-	    assertThat(users.getContent().get(4).getEmail()).isEqualTo("test5@test.com");
 		
 		
 		


### PR DESCRIPTION
회원 다중 조회 기능 구현

- getUserResponse 유저 정보 조회를 페이징 처리하여 반환
- controller , service, repository에 각 기능 구현
- 유저 다중조회 서비스 테스트케이스 작성

resolved : #44 