### PR TITLE
상품 다중 조회 API 앤드포인트 개발

### DIFF
--- a/src/main/java/hello/until/exception/CustomExceptionAdvice.java
+++ b/src/main/java/hello/until/exception/CustomExceptionAdvice.java
@@ -1,11 +1,18 @@
 package hello.until.exception;
 
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class CustomExceptionAdvice {
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<?> validatedExceptionHandler(ConstraintViolationException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ExceptionCode> exceptionHandler(CustomException e){
         return new ResponseEntity<>(e.getCode(), e.getCode().getHttpStatus());

--- a/src/main/java/hello/until/item/controller/ItemController.java
+++ b/src/main/java/hello/until/item/controller/ItemController.java
@@ -8,7 +8,6 @@ import hello.until.item.service.ItemService;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -28,8 +27,8 @@ public class ItemController {
     }
 
     @GetMapping
-    public ReadAllItemResponse readAllItems(@RequestParam @Min(value = 0, message = "페이지는 0 이상이여야 합니다.") Integer page,
-                                           @RequestParam @Min(value = 1, message = "사이즈는 1 이상이여야 합니다.") Integer size) {
+    public ReadAllItemResponse readAllItems(@RequestParam(required = false, defaultValue = "0") @Min(value = 0, message = "페이지는 0 이상이여야 합니다.") Integer page,
+                                           @RequestParam(required = false, defaultValue = "10") @Min(value = 1, message = "사이즈는 1 이상이여야 합니다.") Integer size) {
         return new ReadAllItemResponse(this.itemService.readAllItems(page, size));
     }
 

--- a/src/main/java/hello/until/item/controller/ItemController.java
+++ b/src/main/java/hello/until/item/controller/ItemController.java
@@ -2,14 +2,18 @@ package hello.until.item.controller;
 
 import hello.until.item.dto.request.CreateItemRequest;
 import hello.until.item.dto.response.CreateItemResponse;
+import hello.until.item.dto.response.ReadAllItemResponse;
 import hello.until.item.dto.response.ReadItemResponse;
 import hello.until.item.service.ItemService;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+@Validated
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/items")
@@ -21,6 +25,12 @@ public class ItemController {
         return this.itemService.readItem(id)
                 .map(ReadItemResponse::new)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    }
+
+    @GetMapping
+    public ReadAllItemResponse readAllItem(@RequestParam @Min(value = 0, message = "페이지는 0 이상이여야 합니다.") Integer page,
+                                           @RequestParam @Min(value = 1, message = "사이즈는 1 이상이여야 합니다.") Integer size) {
+        return new ReadAllItemResponse(this.itemService.readAllItems(page, size));
     }
 
     @PostMapping

--- a/src/main/java/hello/until/item/controller/ItemController.java
+++ b/src/main/java/hello/until/item/controller/ItemController.java
@@ -28,7 +28,7 @@ public class ItemController {
     }
 
     @GetMapping
-    public ReadAllItemResponse readAllItem(@RequestParam @Min(value = 0, message = "페이지는 0 이상이여야 합니다.") Integer page,
+    public ReadAllItemResponse readAllItems(@RequestParam @Min(value = 0, message = "페이지는 0 이상이여야 합니다.") Integer page,
                                            @RequestParam @Min(value = 1, message = "사이즈는 1 이상이여야 합니다.") Integer size) {
         return new ReadAllItemResponse(this.itemService.readAllItems(page, size));
     }

--- a/src/main/java/hello/until/item/dto/response/ReadAllItemResponse.java
+++ b/src/main/java/hello/until/item/dto/response/ReadAllItemResponse.java
@@ -1,0 +1,10 @@
+package hello.until.item.dto.response;
+
+import hello.until.item.entity.Item;
+
+import java.util.List;
+
+public record ReadAllItemResponse(
+        List<Item> data
+) {
+}

--- a/src/test/java/hello/until/item/controller/ItemControllerTest.java
+++ b/src/test/java/hello/until/item/controller/ItemControllerTest.java
@@ -76,7 +76,7 @@ class ItemControllerTest {
         void readAllItem() throws Exception {
             // given
             int page = 0;
-            int size = 10;
+            int size = 20;
 
             PageRequest pageRequest = PageRequest.of(page, size);
             int startIdx = (int) pageRequest.getOffset();
@@ -120,6 +120,52 @@ class ItemControllerTest {
         }
 
         @Test
+        @DisplayName("페이지와 사이즈 없이 상품 목록을 조회하면 페이지 0, 사이즈 10을 기준으로 목록을 조회하여 반환한다.")
+        void readAllItemNoPageAndSize() throws Exception {
+            // given
+            int page = 0;
+            int size = 10;
+
+            PageRequest pageRequest = PageRequest.of(page, size);
+            int startIdx = (int) pageRequest.getOffset();
+            int endIdx = Math.min(startIdx + pageRequest.getPageSize(), testItems.size());
+
+            when(itemService.readAllItems(page, size))
+                    .thenReturn(this.testItems.subList(startIdx, endIdx));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(get("/items"));
+
+            // then
+            // httpStatus 와 contentType 검증
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+            // data 검증
+            int resultIdx = 0;
+            int itemsIdx = startIdx;
+
+            for (;resultIdx < size; resultIdx++, itemsIdx++) {
+                String base = String.format("$.data[%d]", resultIdx);
+                resultActions
+                        .andExpect(jsonPath(base + ".id").value(this.testItems.get(itemsIdx).getId().toString()))
+                        .andExpect(jsonPath(base + ".name").value(this.testItems.get(itemsIdx).getName()))
+                        .andExpect(jsonPath(base + ".price").value(this.testItems.get(itemsIdx).getPrice()))
+                        .andExpect(jsonPath(base + ".createdAt").value(this.testItems.get(itemsIdx).getCreatedAt().toString().replaceAll("^0+|0+$", "")))
+                        .andExpect(jsonPath(base + ".updatedAt").value(this.testItems.get(itemsIdx).getUpdatedAt().toString().replaceAll("^0+|0+$", "")));
+            }
+
+            var pageCaptor = ArgumentCaptor.forClass(Integer.class);
+            var sizeCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(itemService, times(1)).readAllItems(pageCaptor.capture(), sizeCaptor.capture());
+
+            var passedPage = pageCaptor.getValue();
+            var passedSize = sizeCaptor.getValue();
+            assertThat(passedPage.equals(page)).isTrue();
+            assertThat(passedSize.equals(size)).isTrue();
+        }
+
+        @Test
         @DisplayName("페이지 없이 사이즈만으로 상품 목록을 조회하면 400을 반환한다.")
         void readAllItemNoPage() throws Exception {
             mockMvc
@@ -134,14 +180,6 @@ class ItemControllerTest {
             mockMvc
                     .perform(get("/items")
                             .param("page", String.valueOf(0)))
-                    .andExpect(status().isBadRequest());
-        }
-
-        @Test
-        @DisplayName("페이지와 사이즈 없이 상품 목록을 조회하면 400을 반환한다.")
-        void readAllItemNoPageAndSize() throws Exception {
-            mockMvc
-                    .perform(get("/items"))
                     .andExpect(status().isBadRequest());
         }
 

--- a/src/test/java/hello/until/item/controller/ItemControllerTest.java
+++ b/src/test/java/hello/until/item/controller/ItemControllerTest.java
@@ -6,21 +6,25 @@ import hello.until.item.entity.Item;
 import hello.until.item.service.ItemService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -44,13 +48,139 @@ class ItemControllerTest {
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();
+
     }
+
+    @Nested
+    class ReadAll {
+        private List<Item> testItems;
+
+        @BeforeEach
+        void beforeEach() {
+            int itemsCount = 100;
+            this.testItems = new ArrayList<>();
+
+            for (long id = itemsCount; id > 0; id--) {
+                this.testItems.add(Item.builder()
+                        .id(id)
+                        .name("테스트 상품 " + id)
+                        .price(10_000)
+                        .createdAt(LocalDateTime.now())
+                        .updatedAt(LocalDateTime.now())
+                        .build());
+            }
+        }
+
+        @Test
+        @DisplayName("페이지와 사이즈를 이용해 상품 목록을 조회 한다.")
+        void readAllItem() throws Exception {
+            // given
+            int page = 0;
+            int size = 10;
+
+            PageRequest pageRequest = PageRequest.of(page, size);
+            int startIdx = (int) pageRequest.getOffset();
+            int endIdx = Math.min(startIdx + pageRequest.getPageSize(), testItems.size());
+
+            when(itemService.readAllItems(page, size))
+                    .thenReturn(this.testItems.subList(startIdx, endIdx));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(get("/items")
+                    .param("page", String.valueOf(page))
+                    .param("size", String.valueOf(size)));
+
+            // then
+            // httpStatus 와 contentType 검증
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+            // data 검증
+            int resultIdx = 0;
+            int itemsIdx = startIdx;
+
+            for (;resultIdx < size; resultIdx++, itemsIdx++) {
+                String base = String.format("$.data[%d]", resultIdx);
+                resultActions
+                    .andExpect(jsonPath(base + ".id").value(this.testItems.get(itemsIdx).getId().toString()))
+                    .andExpect(jsonPath(base + ".name").value(this.testItems.get(itemsIdx).getName()))
+                    .andExpect(jsonPath(base + ".price").value(this.testItems.get(itemsIdx).getPrice()))
+                    .andExpect(jsonPath(base + ".createdAt").value(this.testItems.get(itemsIdx).getCreatedAt().toString().replaceAll("^0+|0+$", "")))
+                    .andExpect(jsonPath(base + ".updatedAt").value(this.testItems.get(itemsIdx).getUpdatedAt().toString().replaceAll("^0+|0+$", "")));
+            }
+
+            var pageCaptor = ArgumentCaptor.forClass(Integer.class);
+            var sizeCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(itemService, times(1)).readAllItems(pageCaptor.capture(), sizeCaptor.capture());
+
+            var passedPage = pageCaptor.getValue();
+            var passedSize = sizeCaptor.getValue();
+            assertThat(passedPage.equals(page)).isTrue();
+            assertThat(passedSize.equals(size)).isTrue();
+        }
+
+        @Test
+        @DisplayName("페이지 없이 사이즈만으로 상품 목록을 조회하면 400을 반환한다.")
+        void readAllItemNoPage() throws Exception {
+            mockMvc
+                    .perform(get("/items")
+                        .param("size", String.valueOf(10)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("사이즈 없이 페이지만으로 상품 목록을 조회하면 400을 반환한다.")
+        void readAllItemNoSize() throws Exception {
+            mockMvc
+                    .perform(get("/items")
+                            .param("page", String.valueOf(0)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("페이지와 사이즈 없이 상품 목록을 조회하면 400을 반환한다.")
+        void readAllItemNoPageAndSize() throws Exception {
+            mockMvc
+                    .perform(get("/items"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("페이지를 -1 로 상품 목록을 조회하면 400과 실패 메시지를 반환한다.")
+        void readAllItemPageIsInvalid() throws Exception {
+            int page = -1;
+            int size = 10;
+
+            mockMvc
+                    .perform(get("/items")
+                        .param("page", String.valueOf(page))
+                        .param("size", String.valueOf(size)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string("readAllItem.page: 페이지는 0 이상이여야 합니다."));
+        }
+
+        @Test
+        @DisplayName("사이즈를 0 으로 상품 목록을 조회하면 400과 실패 메시지를 반환한다.")
+        void readAllItemSizeIsInvalid() throws Exception {
+            int page = -1;
+            int size = 10;
+
+            mockMvc
+                    .perform(get("/items")
+                            .param("page", String.valueOf(page))
+                            .param("size", String.valueOf(size)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string("readAllItem.size: 사이즈는 1 이상이여야 합니다."));
+        }
+    }
+
+
 
     @Test
     @DisplayName("상품명, 상품 가격을 이용해 상품을 등록 한다.")
     void createItem() throws Exception {
         // given
-        Mockito.when(itemService.createItem(testItem.getName(), testItem.getPrice()))
+        when(itemService.createItem(testItem.getName(), testItem.getPrice()))
                 .thenReturn(testItem);
 
         // when & then


### PR DESCRIPTION
## 개요
- related issue : #40 

## 구현 내용
- 페이지, 사이즈로 다중 상품 조회
- 페아지, 사이즈가 없으면 400 으로 응답
- 페이지는 0부터 시작 (첫 페이지 번호가 0)
- 사이즈는 1 이상