### PR TITLE
feat: user Role 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/hello/until/UntilApplication.java
+++ b/src/main/java/hello/until/UntilApplication.java
@@ -2,8 +2,10 @@ package hello.until;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class UntilApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/hello/until/exception/CustomException.java
+++ b/src/main/java/hello/until/exception/CustomException.java
@@ -1,0 +1,10 @@
+package hello.until.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException {
+    private final ExceptionCode code;
+}

--- a/src/main/java/hello/until/exception/CustomException.java
+++ b/src/main/java/hello/until/exception/CustomException.java
@@ -7,4 +7,5 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CustomException extends RuntimeException {
     private final ExceptionCode code;
+
 }

--- a/src/main/java/hello/until/exception/CustomExceptionAdvice.java
+++ b/src/main/java/hello/until/exception/CustomExceptionAdvice.java
@@ -6,8 +6,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class CustomExceptionAdvice {
-    @ExceptionHandler
-    public ResponseEntity<ExceptionCode> handleCustomException(CustomException e) {
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ExceptionCode> exceptionHandler(CustomException e){
         return new ResponseEntity<>(e.getCode(), e.getCode().getHttpStatus());
     }
 }

--- a/src/main/java/hello/until/exception/CustomExceptionAdvice.java
+++ b/src/main/java/hello/until/exception/CustomExceptionAdvice.java
@@ -1,0 +1,13 @@
+package hello.until.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class CustomExceptionAdvice {
+    @ExceptionHandler
+    public ResponseEntity<ExceptionCode> handleCustomException(CustomException e) {
+        return new ResponseEntity<>(e.getCode(), e.getCode().getHttpStatus());
+    }
+}

--- a/src/main/java/hello/until/exception/ExceptionCode.java
+++ b/src/main/java/hello/until/exception/ExceptionCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ExceptionCode {
+    NO_USER_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 유저가 없습니다."),
     NO_ITEM_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 상품이 없습니다.");
 
     @JsonIgnore

--- a/src/main/java/hello/until/exception/ExceptionCode.java
+++ b/src/main/java/hello/until/exception/ExceptionCode.java
@@ -1,0 +1,14 @@
+package hello.until.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ExceptionCode {
+    NO_ITEM_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 상품이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/hello/until/exception/ExceptionCode.java
+++ b/src/main/java/hello/until/exception/ExceptionCode.java
@@ -1,14 +1,18 @@
 package hello.until.exception;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ExceptionCode {
     NO_ITEM_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 상품이 없습니다.");
 
+    @JsonIgnore
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/hello/until/exception/ExceptionCode.java
+++ b/src/main/java/hello/until/exception/ExceptionCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ExceptionCode {
+	NO_USER_TO_GET(HttpStatus.BAD_REQUEST, "해당 유저 정보가 없습니다."),
     NO_USER_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 유저가 없습니다."),
     NO_ITEM_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 상품이 없습니다."),
     DUPLICATE_EMAIL_USER_TO_CREATE(HttpStatus.CONFLICT, "이미 가입 된 회원 메일입니다.");

--- a/src/main/java/hello/until/exception/ExceptionCode.java
+++ b/src/main/java/hello/until/exception/ExceptionCode.java
@@ -11,7 +11,9 @@ import org.springframework.http.HttpStatus;
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ExceptionCode {
     NO_USER_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 유저가 없습니다."),
-    NO_ITEM_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 상품이 없습니다.");
+    NO_ITEM_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 상품이 없습니다."),
+    DUPLICATE_EMAIL_USER_TO_CREATE(HttpStatus.CONFLICT, "이미 가입 된 회원 메일입니다.");
+
 
     @JsonIgnore
     private final HttpStatus httpStatus;

--- a/src/main/java/hello/until/exception/ExceptionCode.java
+++ b/src/main/java/hello/until/exception/ExceptionCode.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 public enum ExceptionCode {
 	NO_USER_TO_GET(HttpStatus.BAD_REQUEST, "해당 유저 정보가 없습니다."),
     NO_USER_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 유저가 없습니다."),
+    NO_USER_ROLE_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 유저 권한 정보가 잘못되었습니다."),
     NO_ITEM_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 상품이 없습니다."),
     DUPLICATE_EMAIL_USER_TO_CREATE(HttpStatus.CONFLICT, "이미 가입 된 회원 메일입니다.");
 

--- a/src/main/java/hello/until/item/controller/ItemController.java
+++ b/src/main/java/hello/until/item/controller/ItemController.java
@@ -1,0 +1,25 @@
+package hello.until.item.controller;
+
+import hello.until.item.dto.response.ReadItemResponse;
+import hello.until.item.service.ItemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/items")
+public class ItemController {
+    private final ItemService itemService;
+
+    @GetMapping("/{id}")
+    public ReadItemResponse readItem(@PathVariable long id) {
+        return this.itemService.readItem(id)
+                .map(ReadItemResponse::new)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    }
+}

--- a/src/main/java/hello/until/item/controller/ItemController.java
+++ b/src/main/java/hello/until/item/controller/ItemController.java
@@ -1,13 +1,13 @@
 package hello.until.item.controller;
 
+import hello.until.item.dto.request.CreateItemRequest;
+import hello.until.item.dto.response.CreateItemResponse;
 import hello.until.item.dto.response.ReadItemResponse;
 import hello.until.item.service.ItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 @RequiredArgsConstructor
@@ -21,5 +21,13 @@ public class ItemController {
         return this.itemService.readItem(id)
                 .map(ReadItemResponse::new)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    }
+
+    @PostMapping
+    public CreateItemResponse createItem(@RequestBody @Validated CreateItemRequest createItemRequest) {
+        String name = createItemRequest.name();
+        Integer price = createItemRequest.price();
+
+        return new CreateItemResponse(this.itemService.createItem(name, price));
     }
 }

--- a/src/main/java/hello/until/item/dto/request/CreateItemRequest.java
+++ b/src/main/java/hello/until/item/dto/request/CreateItemRequest.java
@@ -1,0 +1,11 @@
+package hello.until.item.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateItemRequest(
+        @NotEmpty
+        String name,
+        @NotNull
+        Integer price) {
+}

--- a/src/main/java/hello/until/item/dto/response/CreateItemResponse.java
+++ b/src/main/java/hello/until/item/dto/response/CreateItemResponse.java
@@ -1,0 +1,6 @@
+package hello.until.item.dto.response;
+
+import hello.until.item.entity.Item;
+
+public record CreateItemResponse(Item data) {
+}

--- a/src/main/java/hello/until/item/dto/response/ReadItemResponse.java
+++ b/src/main/java/hello/until/item/dto/response/ReadItemResponse.java
@@ -1,0 +1,6 @@
+package hello.until.item.dto.response;
+
+import hello.until.item.entity.Item;
+
+public record ReadItemResponse(Item data) {
+}

--- a/src/main/java/hello/until/item/entity/Item.java
+++ b/src/main/java/hello/until/item/entity/Item.java
@@ -1,0 +1,16 @@
+package hello.until.item.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class Item {
+    private Long id;
+    private String name;
+    private Integer price;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/hello/until/item/entity/Item.java
+++ b/src/main/java/hello/until/item/entity/Item.java
@@ -1,5 +1,9 @@
 package hello.until.item.entity;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,7 +11,10 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Entity
 public class Item {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     private Integer price;

--- a/src/main/java/hello/until/item/entity/Item.java
+++ b/src/main/java/hello/until/item/entity/Item.java
@@ -1,5 +1,7 @@
 package hello.until.item.entity;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -16,6 +18,7 @@ import java.time.LocalDateTime;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 public class Item {
+    @JsonSerialize(using = ToStringSerializer.class)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/hello/until/item/entity/Item.java
+++ b/src/main/java/hello/until/item/entity/Item.java
@@ -1,23 +1,30 @@
 package hello.until.item.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import lombok.Getter;
-import lombok.Setter;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 public class Item {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     private Integer price;
+    @Column(updatable = false, nullable = false)
+    @CreatedDate
     private LocalDateTime createdAt;
+    @Column(nullable = false)
+    @LastModifiedDate
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/hello/until/item/repository/ItemRepository.java
+++ b/src/main/java/hello/until/item/repository/ItemRepository.java
@@ -1,0 +1,8 @@
+package hello.until.item.repository;
+
+import hello.until.item.entity.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+}

--- a/src/main/java/hello/until/item/service/ItemService.java
+++ b/src/main/java/hello/until/item/service/ItemService.java
@@ -1,0 +1,18 @@
+package hello.until.item.service;
+
+import hello.until.item.entity.Item;
+import hello.until.item.repository.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class ItemService {
+    private final ItemRepository itemRepository;
+
+    public Optional<Item> readItem(Long id) {
+        return this.itemRepository.findById(id);
+    }
+}

--- a/src/main/java/hello/until/item/service/ItemService.java
+++ b/src/main/java/hello/until/item/service/ItemService.java
@@ -39,4 +39,9 @@ public class ItemService {
         this.itemRepository.save(item);
         return item;
     }
+
+    @Transactional
+    public void deleteItem(long id) {
+        this.itemRepository.deleteById(id);
+    }
 }

--- a/src/main/java/hello/until/item/service/ItemService.java
+++ b/src/main/java/hello/until/item/service/ItemService.java
@@ -5,9 +5,13 @@ import hello.until.exception.ExceptionCode;
 import hello.until.item.entity.Item;
 import hello.until.item.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -18,6 +22,14 @@ public class ItemService {
 
     public Optional<Item> readItem(long id) {
         return this.itemRepository.findById(id);
+    }
+
+    public List<Item> readAllItems(int page, int size) {
+        Sort sort = Sort.by(Sort.Direction.DESC, "id");
+        PageRequest pageRequest = PageRequest.of(page, size, sort);
+
+        Page<Item> items = itemRepository.findAll(pageRequest);
+        return items.stream().toList();
     }
 
     @Transactional

--- a/src/main/java/hello/until/item/service/ItemService.java
+++ b/src/main/java/hello/until/item/service/ItemService.java
@@ -1,16 +1,18 @@
 package hello.until.item.service;
 
+import hello.until.exception.CustomException;
+import hello.until.exception.ExceptionCode;
 import hello.until.item.entity.Item;
 import hello.until.item.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class ItemService {
     private final ItemRepository itemRepository;
 
@@ -26,5 +28,15 @@ public class ItemService {
                 .build();
 
         return itemRepository.save(item);
+    }
+
+    @Transactional
+    public Item updateItem(long id, String name, int price) {
+        var item = this.itemRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ExceptionCode.NO_ITEM_TO_UPDATE));
+        item.setName(name);
+        item.setPrice(price);
+        this.itemRepository.save(item);
+        return item;
     }
 }

--- a/src/main/java/hello/until/item/service/ItemService.java
+++ b/src/main/java/hello/until/item/service/ItemService.java
@@ -4,7 +4,9 @@ import hello.until.item.entity.Item;
 import hello.until.item.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -14,5 +16,15 @@ public class ItemService {
 
     public Optional<Item> readItem(long id) {
         return this.itemRepository.findById(id);
+    }
+
+    @Transactional
+    public Item createItem(String name, Integer price) {
+        Item item = Item.builder()
+                .name(name)
+                .price(price)
+                .build();
+
+        return itemRepository.save(item);
     }
 }

--- a/src/main/java/hello/until/item/service/ItemService.java
+++ b/src/main/java/hello/until/item/service/ItemService.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 public class ItemService {
     private final ItemRepository itemRepository;
 
-    public Optional<Item> readItem(Long id) {
+    public Optional<Item> readItem(long id) {
         return this.itemRepository.findById(id);
     }
 }

--- a/src/main/java/hello/until/user/constant/Role.java
+++ b/src/main/java/hello/until/user/constant/Role.java
@@ -1,0 +1,5 @@
+package hello.until.user.constant;
+
+public enum Role {
+	SELLER, BUYER
+}

--- a/src/main/java/hello/until/user/controller/UserController.java
+++ b/src/main/java/hello/until/user/controller/UserController.java
@@ -35,16 +35,13 @@ public class UserController {
 	}
 
 	@PatchMapping("/{id}")
-	public ResponseEntity<?> updateUser(@PathVariable Long id,
-										@RequestBody @Valid UpdateUserRequest updateUserRequest){
-		Optional<User> user = userService.updateUser(
+	public ResponseEntity<UserResponse> updateUser(@PathVariable Long id,
+												   @RequestBody @Valid UpdateUserRequest updateUserRequest){
+		User user = userService.updateUser(
 				id,
 				updateUserRequest.email(),
 				updateUserRequest.password());
-		if (user.isPresent())
-			return ResponseEntity.ok(new UserResponse(user.get()));
-		else
-			return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 유저를 찾을 수 없습니다.");
+		return ResponseEntity.ok(new UserResponse(user));
 	}
 
 	@GetMapping("/{id}")

--- a/src/main/java/hello/until/user/controller/UserController.java
+++ b/src/main/java/hello/until/user/controller/UserController.java
@@ -1,12 +1,19 @@
 package hello.until.user.controller;
 
+import java.util.Optional;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import hello.until.user.dto.request.CreateUserRequest;
+import hello.until.user.dto.response.GetUserResponse;
+import hello.until.user.entity.User;
 import hello.until.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -15,14 +22,24 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/users")
 public class UserController {
-	
+
 	private final UserService userService;
-	
+
 	@PostMapping("/join")
-	public ResponseEntity<?> join(@RequestBody @Valid CreateUserRequest createUserRequest){
+	public ResponseEntity<?> join(@RequestBody @Valid CreateUserRequest createUserRequest) {
 		userService.createUser(createUserRequest.getEmail(), createUserRequest.getPassword());
 		return ResponseEntity.ok().build();
 	}
-	
-	
+
+	@GetMapping("/{id}")
+	public ResponseEntity<?> getUserById(@PathVariable long id) {
+
+		Optional<User> user = userService.getUserById(id);
+
+		if (user.isPresent())
+			return ResponseEntity.ok(new GetUserResponse(user.get()));
+		else
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 유저를 찾을 수 없습니다.");
+	}
+
 }

--- a/src/main/java/hello/until/user/controller/UserController.java
+++ b/src/main/java/hello/until/user/controller/UserController.java
@@ -42,7 +42,8 @@ public class UserController {
 		User user = userService.updateUser(
 				id,
 				updateUserRequest.email(),
-				updateUserRequest.password());
+				updateUserRequest.password(),
+				updateUserRequest.role());
 		return new UserResponse(user);
 	}
 

--- a/src/main/java/hello/until/user/controller/UserController.java
+++ b/src/main/java/hello/until/user/controller/UserController.java
@@ -1,0 +1,4 @@
+package hello.until.user.controller;
+
+public class UserController {
+}

--- a/src/main/java/hello/until/user/controller/UserController.java
+++ b/src/main/java/hello/until/user/controller/UserController.java
@@ -1,9 +1,13 @@
 package hello.until.user.controller;
 
+import hello.until.user.dto.request.UpdateUserRequest;
+import hello.until.user.dto.response.UserResponse;
+import hello.until.user.entity.User;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 import java.util.Optional;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import hello.until.user.dto.request.CreateUserRequest;
 import hello.until.user.dto.response.GetUserResponse;
-import hello.until.user.entity.User;
 import hello.until.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +32,19 @@ public class UserController {
 	public ResponseEntity<?> join(@RequestBody @Valid CreateUserRequest createUserRequest) {
 		userService.createUser(createUserRequest.getEmail(), createUserRequest.getPassword());
 		return ResponseEntity.ok().build();
+	}
+
+	@PatchMapping("/{id}")
+	public ResponseEntity<?> updateUser(@PathVariable Long id,
+										@RequestBody @Valid UpdateUserRequest updateUserRequest){
+		Optional<User> user = userService.updateUser(
+				id,
+				updateUserRequest.email(),
+				updateUserRequest.password());
+		if (user.isPresent())
+			return ResponseEntity.ok(new UserResponse(user.get()));
+		else
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 유저를 찾을 수 없습니다.");
 	}
 
 	@GetMapping("/{id}")

--- a/src/main/java/hello/until/user/controller/UserController.java
+++ b/src/main/java/hello/until/user/controller/UserController.java
@@ -17,7 +17,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
+import hello.until.exception.CustomException;
+import hello.until.exception.ExceptionCode;
 import hello.until.user.dto.request.CreateUserRequest;
 import hello.until.user.dto.response.GetUserResponse;
 import hello.until.user.service.UserService;
@@ -32,30 +35,27 @@ public class UserController {
 	private final UserService userService;
 
 	@PostMapping("/join")
-	public ResponseEntity<?> join(@RequestBody @Valid CreateUserRequest createUserRequest) {
+	public void join(@RequestBody @Valid CreateUserRequest createUserRequest) {
 		userService.createUser(createUserRequest.getEmail(), createUserRequest.getPassword());
-		return ResponseEntity.ok().build();
 	}
 
 	@PatchMapping("/{id}")
-	public ResponseEntity<UserResponse> updateUser(@PathVariable Long id,
+	public UserResponse updateUser(@PathVariable Long id,
 												   @RequestBody @Valid UpdateUserRequest updateUserRequest){
 		User user = userService.updateUser(
 				id,
 				updateUserRequest.email(),
 				updateUserRequest.password());
-		return ResponseEntity.ok(new UserResponse(user));
+		return new UserResponse(user);
 	}
 
 	@GetMapping("/{id}")
-	public ResponseEntity<?> getUserById(@PathVariable long id) {
+	public GetUserResponse getUserById(@PathVariable long id) {
 
-		Optional<User> user = userService.getUserById(id);
+		return userService.getUserById(id)
+				.map(GetUserResponse::new)
+				.orElseThrow(() -> new CustomException(ExceptionCode.NO_USER_TO_GET));
 
-		if (user.isPresent())
-			return ResponseEntity.ok(new GetUserResponse(user.get()));
-		else
-			return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 유저를 찾을 수 없습니다.");
 	}
 	
 	@GetMapping("/getUsers")

--- a/src/main/java/hello/until/user/controller/UserController.java
+++ b/src/main/java/hello/until/user/controller/UserController.java
@@ -7,6 +7,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -53,6 +56,14 @@ public class UserController {
 			return ResponseEntity.ok(new GetUserResponse(user.get()));
 		else
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 유저를 찾을 수 없습니다.");
+	}
+	
+	@GetMapping("/getUsers")
+	public  Page<GetUserResponse> getUsers(Optional<Integer> page) {
+		Pageable pageable  = PageRequest.of(page.isPresent() ? page.get() : 0, 5);
+        Page<User> userPage = userService.getUsers(pageable);
+        return userPage.map(user -> new GetUserResponse(user));
+
 	}
 
 }

--- a/src/main/java/hello/until/user/controller/UserController.java
+++ b/src/main/java/hello/until/user/controller/UserController.java
@@ -1,4 +1,28 @@
 package hello.until.user.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import hello.until.user.dto.request.CreateUserRequest;
+import hello.until.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
 public class UserController {
+	
+	private final UserService userService;
+	
+	@PostMapping("/join")
+	public ResponseEntity<?> join(@RequestBody @Valid CreateUserRequest createUserRequest){
+		userService.createUser(createUserRequest.getEmail(), createUserRequest.getPassword());
+		return ResponseEntity.ok().build();
+	}
+	
+	
 }

--- a/src/main/java/hello/until/user/controller/UserController.java
+++ b/src/main/java/hello/until/user/controller/UserController.java
@@ -1,28 +1,25 @@
 package hello.until.user.controller;
 
-import hello.until.user.dto.request.UpdateUserRequest;
-import hello.until.user.dto.response.UserResponse;
-import hello.until.user.entity.User;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 
 import hello.until.exception.CustomException;
 import hello.until.exception.ExceptionCode;
 import hello.until.user.dto.request.CreateUserRequest;
+import hello.until.user.dto.request.UpdateUserRequest;
 import hello.until.user.dto.response.GetUserResponse;
+import hello.until.user.dto.response.UserResponse;
+import hello.until.user.entity.User;
 import hello.until.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/hello/until/user/dto/request/CreateUserRequest.java
+++ b/src/main/java/hello/until/user/dto/request/CreateUserRequest.java
@@ -1,0 +1,17 @@
+package hello.until.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class CreateUserRequest {
+
+    @Email(message = "올바른 이메일 형식을 입력해주세요.")
+    private String email;
+    @Size(min=8, max = 20, message = "비밀번호는 8자리 이상 20자 이하로 입력해주세요.")
+    private String password;
+
+}

--- a/src/main/java/hello/until/user/dto/request/Request.java
+++ b/src/main/java/hello/until/user/dto/request/Request.java
@@ -1,4 +1,0 @@
-package hello.until.user.dto.request;
-
-public class Request {
-}

--- a/src/main/java/hello/until/user/dto/request/Request.java
+++ b/src/main/java/hello/until/user/dto/request/Request.java
@@ -1,0 +1,4 @@
+package hello.until.user.dto.request;
+
+public class Request {
+}

--- a/src/main/java/hello/until/user/dto/request/UpdateUserRequest.java
+++ b/src/main/java/hello/until/user/dto/request/UpdateUserRequest.java
@@ -1,0 +1,7 @@
+package hello.until.user.dto.request;
+
+public record UpdateUserRequest(
+        String email,
+        String password){
+
+}

--- a/src/main/java/hello/until/user/dto/request/UpdateUserRequest.java
+++ b/src/main/java/hello/until/user/dto/request/UpdateUserRequest.java
@@ -1,7 +1,10 @@
 package hello.until.user.dto.request;
 
+import hello.until.user.constant.Role;
+
 public record UpdateUserRequest(
         String email,
-        String password){
+        String password,
+        String role){
 
 }

--- a/src/main/java/hello/until/user/dto/response/GetUserResponse.java
+++ b/src/main/java/hello/until/user/dto/response/GetUserResponse.java
@@ -1,0 +1,21 @@
+package hello.until.user.dto.response;
+
+import java.time.LocalDateTime;
+
+import hello.until.user.entity.User;
+import lombok.Getter;
+
+@Getter
+public class GetUserResponse {
+    private final Long id;
+    private final String email;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public GetUserResponse(User user){
+        this.id = user.getId();
+        this.email = user.getEmail();
+        this.createdAt = user.getCreatedAt();
+        this.updatedAt = user.getUpdatedAt();
+    }
+}

--- a/src/main/java/hello/until/user/dto/response/GetUserResponse.java
+++ b/src/main/java/hello/until/user/dto/response/GetUserResponse.java
@@ -2,6 +2,7 @@ package hello.until.user.dto.response;
 
 import java.time.LocalDateTime;
 
+import hello.until.user.constant.Role;
 import hello.until.user.entity.User;
 import lombok.Getter;
 
@@ -9,12 +10,14 @@ import lombok.Getter;
 public class GetUserResponse {
     private final Long id;
     private final String email;
+    private final Role role;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
     public GetUserResponse(User user){
         this.id = user.getId();
         this.email = user.getEmail();
+        this.role = user.getRole();
         this.createdAt = user.getCreatedAt();
         this.updatedAt = user.getUpdatedAt();
     }

--- a/src/main/java/hello/until/user/dto/response/Response.java
+++ b/src/main/java/hello/until/user/dto/response/Response.java
@@ -1,0 +1,4 @@
+package hello.until.user.dto.response;
+
+public class Response {
+}

--- a/src/main/java/hello/until/user/dto/response/Response.java
+++ b/src/main/java/hello/until/user/dto/response/Response.java
@@ -1,4 +1,0 @@
-package hello.until.user.dto.response;
-
-public class Response {
-}

--- a/src/main/java/hello/until/user/dto/response/UserResponse.java
+++ b/src/main/java/hello/until/user/dto/response/UserResponse.java
@@ -1,0 +1,19 @@
+package hello.until.user.dto.response;
+
+import hello.until.user.entity.User;
+
+import java.time.LocalDateTime;
+
+public class UserResponse {
+    private final Long id;
+    private final String email;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public UserResponse(User user){
+        this.id = user.getId();
+        this.email = user.getEmail();
+        this.createdAt = user.getCreatedAt();
+        this.updatedAt = user.getUpdatedAt();
+    }
+}

--- a/src/main/java/hello/until/user/dto/response/UserResponse.java
+++ b/src/main/java/hello/until/user/dto/response/UserResponse.java
@@ -1,9 +1,9 @@
 package hello.until.user.dto.response;
 
+import java.time.LocalDateTime;
+
 import hello.until.user.entity.User;
 import lombok.Getter;
-
-import java.time.LocalDateTime;
 
 @Getter
 public class UserResponse {

--- a/src/main/java/hello/until/user/dto/response/UserResponse.java
+++ b/src/main/java/hello/until/user/dto/response/UserResponse.java
@@ -2,6 +2,7 @@ package hello.until.user.dto.response;
 
 import java.time.LocalDateTime;
 
+import hello.until.user.constant.Role;
 import hello.until.user.entity.User;
 import lombok.Getter;
 
@@ -9,12 +10,14 @@ import lombok.Getter;
 public class UserResponse {
     private final Long id;
     private final String email;
+    private final Role role;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
     public UserResponse(User user){
         this.id = user.getId();
         this.email = user.getEmail();
+        this.role = user.getRole();
         this.createdAt = user.getCreatedAt();
         this.updatedAt = user.getUpdatedAt();
     }

--- a/src/main/java/hello/until/user/dto/response/UserResponse.java
+++ b/src/main/java/hello/until/user/dto/response/UserResponse.java
@@ -1,9 +1,11 @@
 package hello.until.user.dto.response;
 
 import hello.until.user.entity.User;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+@Getter
 public class UserResponse {
     private final Long id;
     private final String email;

--- a/src/main/java/hello/until/user/entity/User.java
+++ b/src/main/java/hello/until/user/entity/User.java
@@ -52,4 +52,10 @@ public class User {
         }
     }
 
+    public void updateRole(Role role){
+        if(role != null){
+            this.role = role;
+        }
+    }
+    
 }

--- a/src/main/java/hello/until/user/entity/User.java
+++ b/src/main/java/hello/until/user/entity/User.java
@@ -6,9 +6,12 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import hello.until.user.constant.Role;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -26,7 +29,10 @@ public class User {
 
     private String email;
     private String password;
-
+    
+    @Enumerated(EnumType.STRING)
+    private Role role;
+    
     @Column(updatable = false, nullable = false)
     @CreatedDate
     private LocalDateTime createdAt;

--- a/src/main/java/hello/until/user/entity/User.java
+++ b/src/main/java/hello/until/user/entity/User.java
@@ -23,4 +23,19 @@ public class User {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    public void updateEmail(String email){
+        if(email != null){
+            LocalDateTime currentDateTime = LocalDateTime.now();
+            this.email = email;
+            this.updatedAt = currentDateTime;
+        }
+    }
+    public void updatePassword(String password){
+        if(password != null){
+            LocalDateTime currentDateTime = LocalDateTime.now();
+            this.password = password;
+            this.updatedAt = currentDateTime;
+        }
+    }
+
 }

--- a/src/main/java/hello/until/user/entity/User.java
+++ b/src/main/java/hello/until/user/entity/User.java
@@ -2,7 +2,13 @@ package hello.until.user.entity;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -12,6 +18,7 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
+@EntityListeners(AuditingEntityListener.class)
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -20,21 +27,22 @@ public class User {
     private String email;
     private String password;
 
+    @Column(updatable = false, nullable = false)
+    @CreatedDate
     private LocalDateTime createdAt;
+    
+    @Column(nullable = false)
+    @LastModifiedDate
     private LocalDateTime updatedAt;
 
     public void updateEmail(String email){
         if(email != null){
-            LocalDateTime currentDateTime = LocalDateTime.now();
             this.email = email;
-            this.updatedAt = currentDateTime;
         }
     }
     public void updatePassword(String password){
         if(password != null){
-            LocalDateTime currentDateTime = LocalDateTime.now();
             this.password = password;
-            this.updatedAt = currentDateTime;
         }
     }
 

--- a/src/main/java/hello/until/user/entity/User.java
+++ b/src/main/java/hello/until/user/entity/User.java
@@ -1,13 +1,13 @@
 package hello.until.user.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -19,6 +19,7 @@ public class User {
 
     private String email;
     private String password;
+
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 

--- a/src/main/java/hello/until/user/entity/User.java
+++ b/src/main/java/hello/until/user/entity/User.java
@@ -1,0 +1,25 @@
+package hello.until.user.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+    private String password;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/hello/until/user/repository/UserRepository.java
+++ b/src/main/java/hello/until/user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package hello.until.user.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import hello.until.user.entity.User;
@@ -9,4 +11,6 @@ import hello.until.user.entity.User;
 public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findByEmail(String email);
+	
+	Page<User> findAllByOrderByIdDesc(Pageable pageable);
 }

--- a/src/main/java/hello/until/user/repository/UserRepository.java
+++ b/src/main/java/hello/until/user/repository/UserRepository.java
@@ -9,5 +9,4 @@ import hello.until.user.entity.User;
 public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findByEmail(String email);
-
 }

--- a/src/main/java/hello/until/user/repository/UserRepository.java
+++ b/src/main/java/hello/until/user/repository/UserRepository.java
@@ -1,4 +1,13 @@
 package hello.until.user.repository;
 
-public interface UserRepository {
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import hello.until.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+	Optional<User> findByEmail(String email);
+
 }

--- a/src/main/java/hello/until/user/repository/UserRepository.java
+++ b/src/main/java/hello/until/user/repository/UserRepository.java
@@ -1,0 +1,4 @@
+package hello.until.user.repository;
+
+public interface UserRepository {
+}

--- a/src/main/java/hello/until/user/service/UserService.java
+++ b/src/main/java/hello/until/user/service/UserService.java
@@ -1,0 +1,4 @@
+package hello.until.user.service;
+
+public class UserService {
+}

--- a/src/main/java/hello/until/user/service/UserService.java
+++ b/src/main/java/hello/until/user/service/UserService.java
@@ -1,4 +1,41 @@
 package hello.until.user.service;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hello.until.user.entity.User;
+import hello.until.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
 public class UserService {
+	
+	private final UserRepository userRepository;
+	
+	@Transactional 
+	public void createUser(String email, String password) {
+		
+		LocalDateTime currentDateTime = LocalDateTime.now();
+		validateUser(email); 
+			
+		User user = new User();
+		user.setEmail(email);
+		user.setPassword(password);
+		user.setCreatedAt(currentDateTime);
+		user.setUpdatedAt(currentDateTime);
+		userRepository.save(user);
+		
+	}
+	
+	private void validateUser(String email) {
+		Optional<User> user = userRepository.findByEmail(email);
+		
+		if(user.isPresent())
+			throw new IllegalStateException("이미 가입 된 회원 메일입니다.");
+		
+	}
 }

--- a/src/main/java/hello/until/user/service/UserService.java
+++ b/src/main/java/hello/until/user/service/UserService.java
@@ -3,12 +3,13 @@ package hello.until.user.service;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import hello.until.exception.CustomException;
+import hello.until.exception.ExceptionCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import hello.until.user.entity.User;
 import hello.until.user.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -39,18 +40,14 @@ public class UserService {
 			throw new IllegalStateException("이미 가입 된 회원 메일입니다.");
 	}
 
-	public Optional<User> updateUser(long userId, String email, String password){
-		Optional<User> opUser = this.getUserById(userId);
-		if(opUser.isPresent()){
-			User user = opUser.get();
-			user.updateEmail(email);
-			user.updatePassword(password);
-			user = userRepository.save(user);
-			return Optional.ofNullable(user);
-		}
-		else{
-			return Optional.empty();
-		}
+	public User updateUser(long userId, String email, String password){
+		User user = this.getUserById(userId).orElseThrow(
+				() -> new CustomException(ExceptionCode.NO_USER_TO_UPDATE)
+		);
+
+		user.updateEmail(email);
+		user.updatePassword(password);
+		return userRepository.save(user);
 	}
 
     @Transactional(readOnly = true)

--- a/src/main/java/hello/until/user/service/UserService.java
+++ b/src/main/java/hello/until/user/service/UserService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import hello.until.exception.CustomException;
 import hello.until.exception.ExceptionCode;
+import hello.until.user.constant.Role;
 import hello.until.user.entity.User;
 import hello.until.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class UserService {
 		User user = new User();
 		user.setEmail(email);
 		user.setPassword(password);
+		user.setRole(Role.BUYER);
 		userRepository.save(user);
 		
 	}

--- a/src/main/java/hello/until/user/service/UserService.java
+++ b/src/main/java/hello/until/user/service/UserService.java
@@ -8,6 +8,8 @@ import hello.until.exception.ExceptionCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import hello.until.exception.CustomException;
+import hello.until.exception.ExceptionCode;
 import hello.until.user.entity.User;
 import hello.until.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,14 +23,11 @@ public class UserService {
 	@Transactional 
 	public void createUser(String email, String password) {
 		
-		LocalDateTime currentDateTime = LocalDateTime.now();
 		validateUser(email); 
 			
 		User user = new User();
 		user.setEmail(email);
 		user.setPassword(password);
-		user.setCreatedAt(currentDateTime);
-		user.setUpdatedAt(currentDateTime);
 		userRepository.save(user);
 		
 	}
@@ -37,7 +36,7 @@ public class UserService {
 		Optional<User> user = userRepository.findByEmail(email);
 		
 		if(user.isPresent())
-			throw new IllegalStateException("이미 가입 된 회원 메일입니다.");
+			throw new CustomException(ExceptionCode.DUPLICATE_EMAIL_USER_TO_CREATE);
 	}
 
 	public User updateUser(long userId, String email, String password){

--- a/src/main/java/hello/until/user/service/UserService.java
+++ b/src/main/java/hello/until/user/service/UserService.java
@@ -39,6 +39,20 @@ public class UserService {
 			throw new IllegalStateException("이미 가입 된 회원 메일입니다.");
 	}
 
+	public Optional<User> updateUser(long userId, String email, String password){
+		Optional<User> opUser = this.getUserById(userId);
+		if(opUser.isPresent()){
+			User user = opUser.get();
+			user.updateEmail(email);
+			user.updatePassword(password);
+			user = userRepository.save(user);
+			return Optional.ofNullable(user);
+		}
+		else{
+			return Optional.empty();
+		}
+	}
+
     @Transactional(readOnly = true)
     public Optional<User> getUserById(long id){
         return userRepository.findById(id);

--- a/src/main/java/hello/until/user/service/UserService.java
+++ b/src/main/java/hello/until/user/service/UserService.java
@@ -8,12 +8,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import hello.until.user.entity.User;
 import hello.until.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
-	
+
 	private final UserRepository userRepository;
 	
 	@Transactional 
@@ -36,6 +37,10 @@ public class UserService {
 		
 		if(user.isPresent())
 			throw new IllegalStateException("이미 가입 된 회원 메일입니다.");
-		
 	}
+
+    @Transactional(readOnly = true)
+    public Optional<User> getUserById(long id){
+        return userRepository.findById(id);
+    }
 }

--- a/src/main/java/hello/until/user/service/UserService.java
+++ b/src/main/java/hello/until/user/service/UserService.java
@@ -3,8 +3,8 @@ package hello.until.user.service;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import hello.until.exception.CustomException;
-import hello.until.exception.ExceptionCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,5 +52,14 @@ public class UserService {
     @Transactional(readOnly = true)
     public Optional<User> getUserById(long id){
         return userRepository.findById(id);
+    }
+    
+    @Transactional(readOnly = true)
+    public Page<User>getUsers(Pageable pageable){
+    	Page<User> users = userRepository.findAllByOrderByIdDesc(pageable);
+		
+    	
+    	return users;
+    	
     }
 }

--- a/src/main/java/hello/until/user/service/UserService.java
+++ b/src/main/java/hello/until/user/service/UserService.java
@@ -20,48 +20,56 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
 	private final UserRepository userRepository;
-	
-	@Transactional 
+
+	@Transactional
 	public void createUser(String email, String password) {
-		
-		validateUser(email); 
-			
+
+		validateUser(email);
+
 		User user = new User();
 		user.setEmail(email);
 		user.setPassword(password);
 		user.setRole(Role.BUYER);
 		userRepository.save(user);
-		
+
 	}
-	
+
 	private void validateUser(String email) {
 		Optional<User> user = userRepository.findByEmail(email);
-		
-		if(user.isPresent())
+
+		if (user.isPresent())
 			throw new CustomException(ExceptionCode.DUPLICATE_EMAIL_USER_TO_CREATE);
 	}
 
-	public User updateUser(long userId, String email, String password){
-		User user = this.getUserById(userId).orElseThrow(
-				() -> new CustomException(ExceptionCode.NO_USER_TO_UPDATE)
-		);
+	public User updateUser(long userId, String email, String password, String role) {
+		User user = this.getUserById(userId).orElseThrow(() -> new CustomException(ExceptionCode.NO_USER_TO_UPDATE));
 
 		user.updateEmail(email);
 		user.updatePassword(password);
+
+		if (role != null && !role.equals("")) {
+			Role updateRole;
+			try {
+				updateRole = Role.valueOf(role.toUpperCase());
+			} catch (IllegalArgumentException ex) {
+				throw new CustomException(ExceptionCode.NO_USER_ROLE_TO_UPDATE);
+			}
+			user.updateRole(updateRole);
+		}
+		
 		return userRepository.save(user);
 	}
 
-    @Transactional(readOnly = true)
-    public Optional<User> getUserById(long id){
-        return userRepository.findById(id);
-    }
-    
-    @Transactional(readOnly = true)
-    public Page<User>getUsers(Pageable pageable){
-    	Page<User> users = userRepository.findAllByOrderByIdDesc(pageable);
-		
-    	
-    	return users;
-    	
-    }
+	@Transactional(readOnly = true)
+	public Optional<User> getUserById(long id) {
+		return userRepository.findById(id);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<User> getUsers(Pageable pageable) {
+		Page<User> users = userRepository.findAllByOrderByIdDesc(pageable);
+
+		return users;
+
+	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,13 @@
-
+spring:
+  datasource:
+    url: jdbc:h2:mem:until
+    username: tester
+    password: qwer!@#$
+    driverClassName: org.h2.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+  h2:
+    console:
+      enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:until
+    url: jdbc:h2:mem:until;NON_KEYWORDS=USER
     username: tester
     password: qwer!@#$
     driverClassName: org.h2.Driver

--- a/src/test/java/hello/until/item/controller/ItemControllerTest.java
+++ b/src/test/java/hello/until/item/controller/ItemControllerTest.java
@@ -1,0 +1,109 @@
+package hello.until.item.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hello.until.item.dto.request.CreateItemRequest;
+import hello.until.item.entity.Item;
+import hello.until.item.service.ItemService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ItemController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+class ItemControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private ItemService itemService;
+    private Item testItem;
+
+    @BeforeEach
+    void beforeEach() {
+        testItem = Item.builder()
+                .id(1L)
+                .name("테스트 상품")
+                .price(10_000)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    @DisplayName("상품명, 상품 가격을 이용해 상품을 등록 한다.")
+    void createItem() throws Exception {
+        // given
+        Mockito.when(itemService.createItem(testItem.getName(), testItem.getPrice()))
+                .thenReturn(testItem);
+
+        // when & then
+        mockMvc
+                .perform(post("/items")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(new CreateItemRequest(testItem.getName(), testItem.getPrice()))))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.data.id").value(testItem.getId().toString()))
+                .andExpect(jsonPath("$.data.name").value(testItem.getName()))
+                .andExpect(jsonPath("$.data.price").value(testItem.getPrice()))
+                .andExpect(jsonPath("$.data.createdAt").value(testItem.getCreatedAt().toString()))
+                .andExpect(jsonPath("$.data.updatedAt").value(testItem.getUpdatedAt().toString()));
+
+        // service 호출 시 name, price 가 동일하게 전달되는지 검증
+        var nameCaptor = ArgumentCaptor.forClass(String.class);
+        var priceCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(itemService, times(1)).createItem(nameCaptor.capture(), priceCaptor.capture());
+
+        var passedName = nameCaptor.getValue();
+        var passedPrice = priceCaptor.getValue();
+        assertThat(testItem.getName().equals(passedName)).isTrue();
+        assertThat(testItem.getPrice().equals(passedPrice)).isTrue();
+    }
+
+    @DisplayName("상품명 없이 상품을 등록하면 400을 반환한다.")
+    @Test
+    void createItemNoName() throws Exception {
+        mockMvc
+                .perform(post("/items")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(new CreateItemRequest(null, testItem.getPrice()))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("상품 가격 없이 상품을 등록하면 400을 반환한다.")
+    @Test
+    void createItemNoPrice() throws Exception {
+        mockMvc
+                .perform(post("/items")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(new CreateItemRequest(testItem.getName(), null))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("상품명과 상품 가격 없이 상품을 등록하면 400을 반환한다.")
+    @Test
+    void createItemNoNameAndPrice() throws Exception {
+        mockMvc
+                .perform(post("/items")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(new CreateItemRequest(null, null))))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/hello/until/item/repository/ItemRepositoryTest.java
+++ b/src/test/java/hello/until/item/repository/ItemRepositoryTest.java
@@ -1,0 +1,71 @@
+package hello.until.item.repository;
+
+import hello.until.item.entity.Item;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ItemRepositoryTest {
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @Test
+    @DisplayName("상품 생성일을 지정하지 않아도 생성일이 등록된다. (테스트에서는 +1초 오차까지 허용)")
+    void autoCreatedAt() {
+        // given
+        var item = Item.builder()
+                .id(1L)
+                .name("테스트 상품")
+                .price(10_000)
+                .build();
+        var expected = LocalDateTime.now().plusSeconds(1);
+
+        // when
+        var savedItem = this.itemRepository.save(item);
+
+        // then
+        var createdAt = savedItem.getCreatedAt();
+        assertThat(createdAt).isNotNull();
+        assertThat(createdAt).isBeforeOrEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("상품 수정일을 지정하지 않아도 수정일이 업데이트된다. (테스트에서는 +1초 오차까지 허용)")
+    void autoUpdatedAt() {
+        // given
+        var item = Item.builder()
+                .id(1L)
+                .name("테스트 상품")
+                .price(10_000)
+                .build();
+        item = this.itemRepository.save(item);
+        var createdAt = item.getCreatedAt();
+
+        var delaySeconds = 5;
+        Awaitility.await()
+                .pollDelay(Duration.ofSeconds(delaySeconds))
+                .until(() -> true);
+        var expected1 = createdAt.plusSeconds(delaySeconds);
+        var expected2 = LocalDateTime.now().plusSeconds(1);
+
+        // when
+        item.setName("수정한 테스트 상품");
+        var updatedItem = this.itemRepository.saveAndFlush(item);
+
+        // then
+        var updatedAt = updatedItem.getUpdatedAt();
+        assertThat(updatedAt).isNotNull();
+        assertThat(updatedAt).isAfterOrEqualTo(expected1);
+        assertThat(updatedAt).isBeforeOrEqualTo(expected2);
+    }
+}

--- a/src/test/java/hello/until/item/service/ItemServiceTest.java
+++ b/src/test/java/hello/until/item/service/ItemServiceTest.java
@@ -27,12 +27,13 @@ class ItemServiceTest {
     void beforeEach() {
         this.itemService = new ItemService(this.itemRepository);
 
-        this.testItem = new Item();
-        this.testItem.setId(1L);
-        this.testItem.setName("테스트 상품");
-        this.testItem.setPrice(10_000);
-        this.testItem.setCreatedAt(LocalDateTime.now());
-        this.testItem.setUpdatedAt(LocalDateTime.now());
+        this.testItem = Item.builder()
+                .id(1L)
+                .name("테스트 상품")
+                .price(10_000)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
     }
 
     @Test

--- a/src/test/java/hello/until/item/service/ItemServiceTest.java
+++ b/src/test/java/hello/until/item/service/ItemServiceTest.java
@@ -1,5 +1,7 @@
 package hello.until.item.service;
 
+import hello.until.exception.CustomException;
+import hello.until.exception.ExceptionCode;
 import hello.until.item.entity.Item;
 import hello.until.item.repository.ItemRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -7,18 +9,17 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
-import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ItemServiceTest {
@@ -46,7 +47,7 @@ class ItemServiceTest {
     void readItem() {
         // given
         var testItemId = this.testItem.getId();
-        Mockito.when(this.itemRepository.findById(testItemId))
+        when(this.itemRepository.findById(testItemId))
                 .thenReturn(Optional.of(this.testItem));
 
         // when
@@ -62,7 +63,7 @@ class ItemServiceTest {
     void readNoItem() {
         // given
         var testItemId = this.testItem.getId();
-        Mockito.when(this.itemRepository.findById(testItemId))
+        when(this.itemRepository.findById(testItemId))
                 .thenReturn(Optional.empty());
 
         // when
@@ -79,7 +80,7 @@ class ItemServiceTest {
         String name = this.testItem.getName();
         Integer price = this.testItem.getPrice();
 
-        Mockito.when(this.itemRepository.save(any(Item.class))).thenReturn(this.testItem);
+        when(this.itemRepository.save(any(Item.class))).thenReturn(this.testItem);
 
         // when
         Item item = itemService.createItem(name, price);
@@ -93,5 +94,57 @@ class ItemServiceTest {
 
         assertThat(name.equals(item.getName())).isTrue();
         assertThat(price.equals(item.getPrice())).isTrue();
+    }
+
+    @Test
+    @DisplayName("존재하는 상품의 이름과 가격을 수정할 수 있다.")
+    void updateItem() {
+        // given
+        var id = this.testItem.getId();
+        var updatedName = this.testItem.getName() + " (수정됨)";
+        var updatedPrice = this.testItem.getPrice() + 10_000;
+        var updatedItem = Item.builder()
+                .id(id)
+                .name(updatedName)
+                .price(updatedPrice)
+                .createdAt(this.testItem.getCreatedAt())
+                .updatedAt(this.testItem.getUpdatedAt())
+                .build();
+        when(this.itemRepository.findById(id))
+                .thenReturn(Optional.of(this.testItem));
+        when(this.itemRepository.save(ArgumentMatchers.any(Item.class)))
+                .thenReturn(updatedItem);
+
+        // when
+        var result = this.itemService.updateItem(id, updatedName, updatedPrice);
+
+        // then
+        var itemCaptor = ArgumentCaptor.forClass(Item.class);
+        verify(this.itemRepository, times(1)).save(itemCaptor.capture());
+        var passedItem = itemCaptor.getValue();
+        assertThat(passedItem.getId()).isEqualTo(id);
+        assertThat(passedItem.getName()).isEqualTo(updatedName);
+        assertThat(passedItem.getPrice()).isEqualTo(updatedPrice);
+
+        assertThat(result.getId()).isEqualTo(id);
+        assertThat(result.getName()).isEqualTo(updatedName);
+        assertThat(result.getPrice()).isEqualTo(updatedPrice);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품을 수정하려고 하면 예외가 발생한다.")
+    void updateNoItem() {
+        // given
+        var noItemId = 100L;
+        when(this.itemRepository.findById(noItemId))
+                .thenReturn(Optional.empty());
+
+        // when
+        var ex = catchThrowable(() -> this.itemService.updateItem(noItemId, "없는 상품", 10_000));
+
+        // then
+        assertThat(ex).isInstanceOf(CustomException.class);
+        var code = ((CustomException) ex).getCode();
+        assertThat(code).isEqualTo(ExceptionCode.NO_ITEM_TO_UPDATE);
     }
 }

--- a/src/test/java/hello/until/item/service/ItemServiceTest.java
+++ b/src/test/java/hello/until/item/service/ItemServiceTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -13,7 +15,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.assertj.core.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 class ItemServiceTest {
@@ -65,5 +70,28 @@ class ItemServiceTest {
 
         // then
         assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("상품명, 상품 가격으로 상품을 등록한다.")
+    void createItem() {
+        // given
+        String name = this.testItem.getName();
+        Integer price = this.testItem.getPrice();
+
+        Mockito.when(this.itemRepository.save(any(Item.class))).thenReturn(this.testItem);
+
+        // when
+        Item item = itemService.createItem(name, price);
+
+        // then
+        var itemCaptor = ArgumentCaptor.forClass(Item.class);
+        verify(itemRepository, times(1)).save(itemCaptor.capture());
+        var passedItem = itemCaptor.getValue();
+        assertThat(name.equals(passedItem.getName())).isTrue();
+        assertThat(price.equals(passedItem.getPrice())).isTrue();
+
+        assertThat(name.equals(item.getName())).isTrue();
+        assertThat(price.equals(item.getPrice())).isTrue();
     }
 }

--- a/src/test/java/hello/until/item/service/ItemServiceTest.java
+++ b/src/test/java/hello/until/item/service/ItemServiceTest.java
@@ -147,4 +147,20 @@ class ItemServiceTest {
         var code = ((CustomException) ex).getCode();
         assertThat(code).isEqualTo(ExceptionCode.NO_ITEM_TO_UPDATE);
     }
+
+    @Test
+    @DisplayName("상품 아이디로 삭제하면 해당 상품 삭제를 Repository 에 요청하고 종료한다.")
+    void deleteItem() {
+        // given
+        // testItem 사용
+
+        // when
+        this.itemService.deleteItem(this.testItem.getId());
+
+        // then
+        var idCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(this.itemRepository, times(1)).deleteById(idCaptor.capture());
+        var passedId = idCaptor.getValue();
+        assertThat(passedId).isEqualTo(this.testItem.getId());
+    }
 }

--- a/src/test/java/hello/until/item/service/ItemServiceTest.java
+++ b/src/test/java/hello/until/item/service/ItemServiceTest.java
@@ -1,0 +1,68 @@
+package hello.until.item.service;
+
+import hello.until.item.entity.Item;
+import hello.until.item.repository.ItemRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class ItemServiceTest {
+    @Mock
+    private ItemRepository itemRepository;
+    private ItemService itemService;
+
+    private Item testItem;
+
+    @BeforeEach
+    void beforeEach() {
+        this.itemService = new ItemService(this.itemRepository);
+
+        this.testItem = new Item();
+        this.testItem.setId(1L);
+        this.testItem.setName("테스트 상품");
+        this.testItem.setPrice(10_000);
+        this.testItem.setCreatedAt(LocalDateTime.now());
+        this.testItem.setUpdatedAt(LocalDateTime.now());
+    }
+
+    @Test
+    @DisplayName("존재하는 상품 아이디로 조회하면 해당 상품을 담은 Optional 객체를 반환한다.")
+    void readItem() {
+        // given
+        var testItemId = this.testItem.getId();
+        Mockito.when(this.itemRepository.findById(testItemId))
+                .thenReturn(Optional.of(this.testItem));
+
+        // when
+        var result = this.itemService.readItem(testItemId);
+
+        // then
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isEqualTo(this.testItem);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품 아이디로 조회하면 빈 Optional 객체를 반환한다.")
+    void readNoItem() {
+        // given
+        var testItemId = this.testItem.getId();
+        Mockito.when(this.itemRepository.findById(testItemId))
+                .thenReturn(Optional.empty());
+
+        // when
+        var result = this.itemService.readItem(testItemId);
+
+        // then
+        assertThat(result.isEmpty()).isTrue();
+    }
+}

--- a/src/test/java/hello/until/user/repository/UserRepositoryTest.java
+++ b/src/test/java/hello/until/user/repository/UserRepositoryTest.java
@@ -1,16 +1,20 @@
 package hello.until.user.repository;
 
 
-import hello.until.user.entity.User;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-import java.time.LocalDateTime;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import hello.until.user.entity.User;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -22,21 +26,20 @@ public class UserRepositoryTest {
     @DisplayName("새 User 저장")
     public void saveUser() {
         // given
-        LocalDateTime currentDateTime = LocalDateTime.now();
         User user = new User();
         user.setId(1L);
         user.setEmail("test@test.com");
         user.setPassword("12345678");
-        user.setCreatedAt(currentDateTime);
-        user.setUpdatedAt(currentDateTime);
+        LocalDateTime expected = LocalDateTime.now().plusSeconds(1);
+        
         // when
         User dbUser = userRepository.save(user);
 
         // then
         assertEquals(dbUser.getEmail(), user.getEmail());
         assertEquals(dbUser.getPassword(), user.getPassword());
-        assertEquals(dbUser.getCreatedAt(), currentDateTime);
-        assertEquals(dbUser.getUpdatedAt(), currentDateTime);
+        assertThat(dbUser.getCreatedAt()).isBefore(expected);
+        assertThat(dbUser.getUpdatedAt()).isBefore(expected);
     }
 
     @Test
@@ -48,17 +51,27 @@ public class UserRepositoryTest {
         user.setId(1L);
         user.setEmail("test@test.com");
         user.setPassword("12345678");
-        user.setCreatedAt(currentDateTime);
-        user.setUpdatedAt(currentDateTime);
         User dbUser = userRepository.save(user);
-        dbUser.updateEmail("test2@test.com");
+        
+        LocalDateTime expected = LocalDateTime.now().plusSeconds(1);
+        
+        int delaySeconds = 3;
+        Awaitility.await()
+                .pollDelay(Duration.ofSeconds(delaySeconds))
+                .until(() -> true);
+       
+        LocalDateTime expectedUpdate1 = dbUser.getCreatedAt().plusSeconds(delaySeconds);
+        LocalDateTime expectedUpdate2 = LocalDateTime.now().plusSeconds(1);
+        
         // when
-        User savedUser = userRepository.save(dbUser);
+        dbUser.updateEmail("test2@test.com");
+        User savedUser = userRepository.saveAndFlush(dbUser);
 
         // then
         assertEquals(dbUser.getEmail(), savedUser.getEmail());
         assertEquals(dbUser.getPassword(), savedUser.getPassword());
-        assertEquals(dbUser.getCreatedAt(), savedUser.getCreatedAt());
-        assertEquals(dbUser.getUpdatedAt(), savedUser.getUpdatedAt());
+        
+        assertThat(savedUser.getUpdatedAt()).isAfterOrEqualTo(expectedUpdate1);
+        assertThat(savedUser.getUpdatedAt()).isBeforeOrEqualTo(expectedUpdate2);
     }
 }

--- a/src/test/java/hello/until/user/repository/UserRepositoryTest.java
+++ b/src/test/java/hello/until/user/repository/UserRepositoryTest.java
@@ -1,0 +1,64 @@
+package hello.until.user.repository;
+
+
+import hello.until.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class UserRepositoryTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("새 User 저장")
+    public void saveUser() {
+        // given
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("test@test.com");
+        user.setPassword("12345678");
+        user.setCreatedAt(currentDateTime);
+        user.setUpdatedAt(currentDateTime);
+        // when
+        User dbUser = userRepository.save(user);
+
+        // then
+        assertEquals(dbUser.getEmail(), user.getEmail());
+        assertEquals(dbUser.getPassword(), user.getPassword());
+        assertEquals(dbUser.getCreatedAt(), currentDateTime);
+        assertEquals(dbUser.getUpdatedAt(), currentDateTime);
+    }
+
+    @Test
+    @DisplayName("회원 정보 수정")
+    public void updateUser() {
+        // given
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("test@test.com");
+        user.setPassword("12345678");
+        user.setCreatedAt(currentDateTime);
+        user.setUpdatedAt(currentDateTime);
+        User dbUser = userRepository.save(user);
+        dbUser.updateEmail("test2@test.com");
+        // when
+        User savedUser = userRepository.save(dbUser);
+
+        // then
+        assertEquals(dbUser.getEmail(), savedUser.getEmail());
+        assertEquals(dbUser.getPassword(), savedUser.getPassword());
+        assertEquals(dbUser.getCreatedAt(), savedUser.getCreatedAt());
+        assertEquals(dbUser.getUpdatedAt(), savedUser.getUpdatedAt());
+    }
+}

--- a/src/test/java/hello/until/user/repository/UserRepositoryTest.java
+++ b/src/test/java/hello/until/user/repository/UserRepositoryTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import hello.until.user.constant.Role;
 import hello.until.user.entity.User;
 
 @DataJpaTest
@@ -30,6 +31,7 @@ public class UserRepositoryTest {
         user.setId(1L);
         user.setEmail("test@test.com");
         user.setPassword("12345678");
+        user.setRole(Role.BUYER);
         LocalDateTime expected = LocalDateTime.now().plusSeconds(1);
         
         // when
@@ -38,8 +40,11 @@ public class UserRepositoryTest {
         // then
         assertEquals(dbUser.getEmail(), user.getEmail());
         assertEquals(dbUser.getPassword(), user.getPassword());
+        assertEquals(dbUser.getRole(), user.getRole());
+        
         assertThat(dbUser.getCreatedAt()).isBefore(expected);
         assertThat(dbUser.getUpdatedAt()).isBefore(expected);
+        
     }
 
     @Test
@@ -53,8 +58,6 @@ public class UserRepositoryTest {
         user.setPassword("12345678");
         User dbUser = userRepository.save(user);
         
-        LocalDateTime expected = LocalDateTime.now().plusSeconds(1);
-        
         int delaySeconds = 3;
         Awaitility.await()
                 .pollDelay(Duration.ofSeconds(delaySeconds))
@@ -65,11 +68,14 @@ public class UserRepositoryTest {
         
         // when
         dbUser.updateEmail("test2@test.com");
+        dbUser.setRole(Role.SELLER);
         User savedUser = userRepository.saveAndFlush(dbUser);
 
         // then
         assertEquals(dbUser.getEmail(), savedUser.getEmail());
         assertEquals(dbUser.getPassword(), savedUser.getPassword());
+        assertEquals(dbUser.getRole(), savedUser.getRole());
+        
         
         assertThat(savedUser.getUpdatedAt()).isAfterOrEqualTo(expectedUpdate1);
         assertThat(savedUser.getUpdatedAt()).isBeforeOrEqualTo(expectedUpdate2);

--- a/src/test/java/hello/until/user/service/UserServiceTest.java
+++ b/src/test/java/hello/until/user/service/UserServiceTest.java
@@ -1,0 +1,55 @@
+package hello.until.user.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hello.until.user.entity.User;
+import hello.until.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+	@Mock
+	private UserRepository userRepository;
+
+	private UserService userService;
+
+	private User testUser;
+
+	@BeforeEach
+	void beforeEach() {
+		userService = new UserService(userRepository);
+
+	}
+
+	@Test
+	@DisplayName("회원가입 테스트")
+	void createUser() {
+
+		String email = "test@test.com";
+		String password = "12341234";
+
+	    testUser = new User(); 
+	    testUser.setEmail(email);
+	    testUser.setPassword(password);
+		
+		Mockito.when(userRepository.save(Mockito.any(User.class))).thenAnswer(invocation -> {
+	        User savedUser = invocation.getArgument(0);
+	        assertEquals(email, savedUser.getEmail()); 
+	        assertEquals(password, savedUser.getPassword()); 
+	        return testUser; 
+	    });
+		userService.createUser(email, password);
+
+		Mockito.verify(this.userRepository, Mockito.times(1)).save(Mockito.any(User.class));
+
+	}
+
+}

--- a/src/test/java/hello/until/user/service/UserServiceTest.java
+++ b/src/test/java/hello/until/user/service/UserServiceTest.java
@@ -1,6 +1,10 @@
 package hello.until.user.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +30,13 @@ public class UserServiceTest {
 	@BeforeEach
 	void beforeEach() {
 		userService = new UserService(userRepository);
-
+		
+	    testUser = new User(); 
+	    testUser.setId(1L);
+	    testUser.setEmail("test@test.com");
+	    testUser.setPassword("12341234");
+	    testUser.setCreatedAt(LocalDateTime.now());
+	    testUser.setUpdatedAt(LocalDateTime.now());
 	}
 
 	@Test
@@ -50,6 +60,39 @@ public class UserServiceTest {
 
 		Mockito.verify(this.userRepository, Mockito.times(1)).save(Mockito.any(User.class));
 
+	}
+	
+	@Test
+	@DisplayName("가입 회원조회 테스트 - Optional 객체 반환")
+	void getUser() {
+
+        // given
+        Long testUserId = this.testUser.getId();
+        Mockito.when(this.userRepository.findById(testUserId))
+                .thenReturn(Optional.of(this.testUser));
+
+        // when
+        Optional<User> result = this.userService.getUserById(testUserId);
+
+        // then
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isEqualTo(this.testUser);
+	}
+	
+	@Test
+	@DisplayName("미가입 회원조회 테스트 - Optional 빈 객체 반환")
+	void getNoUser() {
+
+        // given
+        Long testUserId = this.testUser.getId();
+        Mockito.when(this.userRepository.findById(testUserId))
+                .thenReturn(Optional.empty());
+
+        // when
+        Optional<User> result = this.userService.getUserById(testUserId);
+
+        // then
+        assertThat(result.isEmpty()).isTrue();
 	}
 
 }

--- a/src/test/java/hello/until/user/service/UserServiceTest.java
+++ b/src/test/java/hello/until/user/service/UserServiceTest.java
@@ -35,8 +35,6 @@ public class UserServiceTest {
 	    testUser.setId(1L);
 	    testUser.setEmail("test@test.com");
 	    testUser.setPassword("12341234");
-	    testUser.setCreatedAt(LocalDateTime.now());
-	    testUser.setUpdatedAt(LocalDateTime.now());
 	}
 
 	@Test

--- a/src/test/java/hello/until/user/service/UserServiceTest.java
+++ b/src/test/java/hello/until/user/service/UserServiceTest.java
@@ -3,7 +3,6 @@ package hello.until.user.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import hello.until.user.constant.Role;
 import hello.until.user.entity.User;
 import hello.until.user.repository.UserRepository;
 
@@ -35,6 +35,7 @@ public class UserServiceTest {
 	    testUser.setId(1L);
 	    testUser.setEmail("test@test.com");
 	    testUser.setPassword("12341234");
+	    testUser.setRole(Role.BUYER);
 	}
 
 	@Test
@@ -52,6 +53,7 @@ public class UserServiceTest {
 	        User savedUser = invocation.getArgument(0);
 	        assertEquals(email, savedUser.getEmail()); 
 	        assertEquals(password, savedUser.getPassword()); 
+	        
 	        return testUser; 
 	    });
 		userService.createUser(email, password);


### PR DESCRIPTION
### 개요
-구매자 / 판매자 구별에 필요한 role 추가

### 추가 및 변경 사항
- role enum , user entity role 추가
- user 생성시 기본 role 'BUYER' 설정
- user 수정시 role 변경 설정 
- user 수정/조회 dto에 role 추가
- 일부 테스트 케이스 수정
