### PR TITLE
feat: security config 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.security:spring-security-crypto'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/hello/until/config/SecurityConfig.java
+++ b/src/main/java/hello/until/config/SecurityConfig.java
@@ -2,14 +2,37 @@ package hello.until.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    @Bean
-    public PasswordEncoder  bCryptPasswordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+	@Bean
+	public PasswordEncoder bCryptPasswordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http)
+			throws Exception {
+
+
+		http.csrf(AbstractHttpConfigurer::disable)
+		.authorizeHttpRequests((authorize) -> authorize
+				.anyRequest().permitAll()
+		);
+		return http.build();
+	}
 }

--- a/src/test/java/hello/until/item/controller/ItemControllerTest.java
+++ b/src/test/java/hello/until/item/controller/ItemControllerTest.java
@@ -1,18 +1,32 @@
 package hello.until.item.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import hello.until.exception.CustomException;
-import hello.until.exception.ExceptionCode;
-import hello.until.item.dto.request.CreateItemRequest;
-import hello.until.item.dto.request.UpdateItemRequest;
-import hello.until.item.entity.Item;
-import hello.until.item.service.ItemService;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
@@ -21,19 +35,18 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import hello.until.exception.CustomException;
+import hello.until.exception.ExceptionCode;
+import hello.until.item.dto.request.CreateItemRequest;
+import hello.until.item.dto.request.UpdateItemRequest;
+import hello.until.item.entity.Item;
+import hello.until.item.service.ItemService;
 
 @WebMvcTest(ItemController.class)
 @MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureMockMvc(addFilters = false)
 class ItemControllerTest {
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
### 개요
- spring security 추가
- controller test case add filter = false

controller test case가 security 추가 이후에 403으로 응답을 받아 addFilter 를 false 처리하였습니다.
이후 jwt 이용하여 인증/인가 시스템 구현하도록하겠습니다.

추가적으로 spring security 6.1.3 버전으로 기존 6.1.2과  antMatchers 등록하는 부분이 변경되어 공유 드립니다.


```
           .authorizeHttpRequests((authorize) -> authorize
           .requestMatchers(new AntPathRequestMatcher("/users/**")).permitAll()
           .requestMatchers(new AntPathRequestMatcher("/items/**")).hasAnyRole("SELLER")
           .anyRequest().authenticated()
          );

```

resolved #70 