### PR TITLE
상품과 회원 연관 관계 등록

### DIFF
--- a/src/main/java/hello/until/exception/ExceptionCode.java
+++ b/src/main/java/hello/until/exception/ExceptionCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ExceptionCode {
+    NO_USER_TO_CREATE_ITEM(HttpStatus.BAD_REQUEST, "상품 생성을 위한 유저 정보가 없습니다."),
 	NO_USER_TO_GET(HttpStatus.BAD_REQUEST, "해당 유저 정보가 없습니다."),
     NO_USER_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 유저가 없습니다."),
     NO_ITEM_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 상품이 없습니다."),

--- a/src/main/java/hello/until/exception/ExceptionCode.java
+++ b/src/main/java/hello/until/exception/ExceptionCode.java
@@ -11,7 +11,6 @@ import org.springframework.http.HttpStatus;
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ExceptionCode {
 	NO_USER_TO_GET(HttpStatus.BAD_REQUEST, "해당 유저 정보가 없습니다."),
-    NO_USER_TO_GET(HttpStatus.BAD_REQUEST, "해당 유저 정보가 없습니다."),
     NO_USER_TO_CREATE_ITEM(HttpStatus.BAD_REQUEST, "상품 생성을 위한 유저 정보가 없습니다."),
     NO_USER_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 유저가 없습니다."),
     NO_ITEM_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 상품이 없습니다."),

--- a/src/main/java/hello/until/item/controller/ItemController.java
+++ b/src/main/java/hello/until/item/controller/ItemController.java
@@ -39,8 +39,9 @@ public class ItemController {
     public ItemResponse createItem(@RequestBody @Validated CreateItemRequest createItemRequest) {
         String name = createItemRequest.name();
         Integer price = createItemRequest.price();
+        Long userId = createItemRequest.userId();
 
-        return new ItemResponse(this.itemService.createItem(name, price));
+        return new ItemResponse(this.itemService.createItem(name, price, userId));
     }
 
     @PatchMapping("/{id}")

--- a/src/main/java/hello/until/item/dto/request/CreateItemRequest.java
+++ b/src/main/java/hello/until/item/dto/request/CreateItemRequest.java
@@ -7,5 +7,7 @@ public record CreateItemRequest(
         @NotEmpty
         String name,
         @NotNull
-        Integer price) {
+        Integer price,
+        @NotNull
+        Long userId) {
 }

--- a/src/main/java/hello/until/item/entity/Item.java
+++ b/src/main/java/hello/until/item/entity/Item.java
@@ -1,8 +1,10 @@
 package hello.until.item.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import hello.until.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -33,4 +35,8 @@ public class Item {
     @Column(nullable = false)
     @LastModifiedDate
     private LocalDateTime updatedAt;
+    @JsonIgnore
+    @ManyToOne
+    @JoinColumn(updatable = false)
+    private User user;
 }

--- a/src/main/java/hello/until/item/service/ItemService.java
+++ b/src/main/java/hello/until/item/service/ItemService.java
@@ -38,7 +38,7 @@ public class ItemService {
     @Transactional
     public Item createItem(String name, Integer price, Long userId) {
         if (!userRepository.existsById(userId)) {
-            throw new CustomException(ExceptionCode.NO_USER_TO_GET);
+            throw new CustomException(ExceptionCode.NO_USER_TO_CREATE_ITEM);
         }
 
         User userProxy = userRepository.getReferenceById(userId);

--- a/src/main/java/hello/until/item/service/ItemService.java
+++ b/src/main/java/hello/until/item/service/ItemService.java
@@ -4,6 +4,8 @@ import hello.until.exception.CustomException;
 import hello.until.exception.ExceptionCode;
 import hello.until.item.entity.Item;
 import hello.until.item.repository.ItemRepository;
+import hello.until.user.entity.User;
+import hello.until.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -19,6 +21,7 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 public class ItemService {
     private final ItemRepository itemRepository;
+    private final UserRepository userRepository;
 
     public Optional<Item> readItem(long id) {
         return this.itemRepository.findById(id);
@@ -33,10 +36,17 @@ public class ItemService {
     }
 
     @Transactional
-    public Item createItem(String name, Integer price) {
+    public Item createItem(String name, Integer price, Long userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new CustomException(ExceptionCode.NO_USER_TO_GET);
+        }
+
+        User userProxy = userRepository.getReferenceById(userId);
+
         Item item = Item.builder()
                 .name(name)
                 .price(price)
+                .user(userProxy)
                 .build();
 
         return itemRepository.save(item);

--- a/src/test/java/hello/until/item/controller/ItemControllerTest.java
+++ b/src/test/java/hello/until/item/controller/ItemControllerTest.java
@@ -68,7 +68,7 @@ class ItemControllerTest {
                 .id(1L)
                 .email("test@test.com")
                 .password("12345678")
-                .role(Role.BUYER)
+                .role(Role.SELLER)
                 .build();
 
         testItem = Item.builder()

--- a/src/test/java/hello/until/item/controller/ItemControllerTest.java
+++ b/src/test/java/hello/until/item/controller/ItemControllerTest.java
@@ -64,11 +64,12 @@ class ItemControllerTest {
 
     @BeforeEach
     void beforeEach() {
-        User user = new User();
-        user.setId(1L);
-        user.setEmail("test@test.com");
-        user.setPassword("12345678");
-        user.setRole(Role.BUYER);
+        User user = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .password("12345678")
+                .role(Role.BUYER)
+                .build();
 
         testItem = Item.builder()
                 .id(1L)

--- a/src/test/java/hello/until/item/service/ItemServiceTest.java
+++ b/src/test/java/hello/until/item/service/ItemServiceTest.java
@@ -46,7 +46,7 @@ class ItemServiceTest {
         user.setId(1L);
         user.setEmail("test@test.com");
         user.setPassword("12345678");
-        user.setRole(Role.BUYER);
+        user.setRole(Role.SELLER);
 
         testItem = Item.builder()
                 .id(1L)

--- a/src/test/java/hello/until/item/service/ItemServiceTest.java
+++ b/src/test/java/hello/until/item/service/ItemServiceTest.java
@@ -196,7 +196,7 @@ class ItemServiceTest {
         // then
         assertThat(ex).isInstanceOf(CustomException.class);
         var code = ((CustomException) ex).getCode();
-        assertThat(code).isEqualTo(ExceptionCode.NO_USER_TO_GET);
+        assertThat(code).isEqualTo(ExceptionCode.NO_USER_TO_CREATE_ITEM);
     }
 
     @Test


### PR DESCRIPTION
## 개요
- related issue : #67 

## 구현 내용
- User과 Item 간 다대일 관계 등록
- Item와 연관된 User 정보는 수정 불가능하게 설정
- 기존 테스트를 회원 연관 관계를 적용한 테스트로 수정
- API 회원 ID가 없는 경우를 확인하는 테스트 작성
- Service 등록되지 않은 회원이 상품을 등록하는 경우를 확인하는 테스트 작성